### PR TITLE
feat(email-verification): Send vérification email with signed link

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -39,19 +39,21 @@ class RegistrationController extends AbstractController
             // Default values for new users
             $user->setIsVerified(false);
             $user->setCreatedAt(new \DateTimeImmutable());
-
+            
             $entityManager->persist($user);
             $entityManager->flush();
 
             // generate a signed url and email it to the user
-            $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
+           $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
                 (new TemplatedEmail())
                     ->from(new Address('noreplay@snowtricks.com', 'Dmd Snow trick Project'))
                     ->to((string) $user->getEmail())
-                    ->subject('Please Confirm your Email')
+                    ->subject('Veuiullez confirmer votre adresse e-mail')
                     ->htmlTemplate('registration/confirmation_email.html.twig')
             );
-
+            
+            // Debug: Affichez l'URL signée pour vérifier qu'elle est générée correctement
+            
             // do anything else you need here, like send an email
             
             $this->addFlash('success', 'Votre compte a été créé avec succès. Veuillez vérifier votre adresse e-mail pour confirmer votre inscription.');

--- a/templates/registration/confirmation_email.html.twig
+++ b/templates/registration/confirmation_email.html.twig
@@ -1,11 +1,19 @@
-<h1>Hi! Please confirm your email!</h1>
-
+<h1>
+    Bonjour!
+</h1>
 <p>
-    Please confirm your email address by clicking the following link: <br><br>
-    <a href="{{ signedUrl|raw }}">Confirm my Email</a>.
-    This link will expire in {{ expiresAtMessageKey|trans(expiresAtMessageData, 'VerifyEmailBundle') }}.
-</p>
-
-<p>
-    Cheers!
-</p>
+    Veuillez confirmer votre adresse e-mail en cliquant sur le lien suivant:
+    <br>
+        <br>
+            <a href="{{ signedUrl|raw }}">
+                Confirmer mon adresse e-mail
+            </a>
+            .
+            Ce lien expirera dans
+            {{ expiresAtMessageKey|trans(expiresAtMessageData, 'VerifyEmailBundle') }}
+            .
+        </p><br><br>
+        <p>
+            Merci de votre inscription sur notre site!
+        </p>
+        


### PR DESCRIPTION
Send vérification email with signed link with secure params to user to confirm his email address by clicking on this to be confirmed as user account confirmed.